### PR TITLE
Add algorithm family documentation skeleton

### DIFF
--- a/docs/classic-dp.md
+++ b/docs/classic-dp.md
@@ -1,0 +1,104 @@
+# Classic Dynamic Programming
+
+Model problems with optimal substructure and overlapping subproblems.
+
+## Linear DP
+
+### Fibonacci
+TODO: Implementation forthcoming.
+
+### Longest Increasing Subsequence (LIS)
+TODO: Implementation forthcoming.
+
+### Maximum Subarray (Kadane's Algorithm)
+TODO: Implementation forthcoming.
+
+### House Robber
+TODO: Implementation forthcoming.
+
+### Climbing Stairs
+TODO: Implementation forthcoming.
+
+### Jump Game I & II
+TODO: Implementation forthcoming.
+
+## 2D / Grid-Based DP
+
+### Unique Paths
+TODO: Implementation forthcoming.
+
+### Minimum Path Sum
+TODO: Implementation forthcoming.
+
+### Longest Common Subsequence (LCS)
+TODO: Implementation forthcoming.
+
+### Edit Distance
+TODO: Implementation forthcoming.
+
+### Maximum Square Submatrix
+TODO: Implementation forthcoming.
+
+## Knapsack Variants
+
+### 0/1 Knapsack
+TODO: Implementation forthcoming.
+
+### Unbounded Knapsack
+TODO: Implementation forthcoming.
+
+### Partition Equal Subset Sum
+TODO: Implementation forthcoming.
+
+### Target Sum
+TODO: Implementation forthcoming.
+
+## String DP
+
+### Longest Common Subsequence (LCS)
+TODO: Implementation forthcoming.
+
+### Edit Distance
+TODO: Implementation forthcoming.
+
+### Regular Expression Matching
+TODO: Implementation forthcoming.
+
+### Wildcard Matching
+TODO: Implementation forthcoming.
+
+### Palindromic Substrings
+TODO: Implementation forthcoming.
+
+## Interval DP
+
+### Matrix Chain Multiplication
+TODO: Implementation forthcoming.
+
+### Burst Balloons
+TODO: Implementation forthcoming.
+
+### Palindrome Partitioning
+TODO: Implementation forthcoming.
+
+## Bitmask / Digit DP
+
+### Traveling Salesman Problem (TSP)
+TODO: Implementation forthcoming.
+
+### Assignment Problem
+TODO: Implementation forthcoming.
+
+### Digit Sum Count
+TODO: Implementation forthcoming.
+
+## Tree/DAG DP
+
+### Diameter of Tree
+TODO: Implementation forthcoming.
+
+### House Robber III
+TODO: Implementation forthcoming.
+
+### Longest Path in DAG
+TODO: Implementation forthcoming.

--- a/docs/classical-planning.md
+++ b/docs/classical-planning.md
@@ -1,0 +1,23 @@
+# Classical Planning Algorithms
+
+Solve planning problems in state or configuration space.
+
+## Algorithms
+
+### A*
+TODO: Implementation forthcoming.
+
+### Dijkstra's
+TODO: Implementation forthcoming.
+
+### RRT / PRM
+TODO: Implementation forthcoming.
+
+### STRIPS / PDDL
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Heuristics
+- Search graph expansion
+- Plan execution and validation

--- a/docs/dmps.md
+++ b/docs/dmps.md
@@ -1,0 +1,17 @@
+# Dynamic Movement Primitives
+
+Encode reusable trajectories for motion planning.
+
+## Algorithms
+
+### DMP Encoding/Decoding
+TODO: Implementation forthcoming.
+
+### Imitation Learning Using DMPs
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Nonlinear dynamical systems
+- Attractor landscapes
+- Temporal scaling

--- a/docs/gaussian-process.md
+++ b/docs/gaussian-process.md
@@ -1,0 +1,23 @@
+# Gaussian Process Modeling
+
+Model functions with uncertainty using Bayesian regression.
+
+## Algorithms
+
+### Gaussian Process Regression
+TODO: Implementation forthcoming.
+
+### Sparse Gaussian Processes
+TODO: Implementation forthcoming.
+
+### Bayesian Optimization
+TODO: Implementation forthcoming.
+
+### PILCO
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Kernel functions
+- Posterior predictive distribution
+- Acquisition functions (UCB, EI)

--- a/docs/hrl.md
+++ b/docs/hrl.md
@@ -1,0 +1,23 @@
+# Hierarchical Reinforcement Learning
+
+Introduce temporal abstraction and multi-level decision-making.
+
+## Algorithms
+
+### Options Framework
+TODO: Implementation forthcoming.
+
+### Feudal Reinforcement Learning
+TODO: Implementation forthcoming.
+
+### MAXQ Decomposition
+TODO: Implementation forthcoming.
+
+### HIRO
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Subgoals
+- Macro-actions
+- Inter-option policy training

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,79 @@
 
 [:material-book-open: Documentation](api.md) · [:material-code-braces: Source Code](https://github.com/jeffrichley/algokit) · [:material-github: GitHub](https://github.com/jeffrichley/algokit)
 
+## Algorithm Families
+
+- [Classic Dynamic Programming](classic-dp.md)
+  - Linear DP
+    - [Fibonacci](classic-dp.md#fibonacci)
+    - [Longest Increasing Subsequence (LIS)](classic-dp.md#longest-increasing-subsequence-lis)
+    - [Maximum Subarray (Kadane's Algorithm)](classic-dp.md#maximum-subarray-kadane-s-algorithm)
+    - [House Robber](classic-dp.md#house-robber)
+    - [Climbing Stairs](classic-dp.md#climbing-stairs)
+    - [Jump Game I & II](classic-dp.md#jump-game-i-ii)
+  - 2D / Grid-Based DP
+    - [Unique Paths](classic-dp.md#unique-paths)
+    - [Minimum Path Sum](classic-dp.md#minimum-path-sum)
+    - [Longest Common Subsequence (LCS)](classic-dp.md#longest-common-subsequence-lcs)
+    - [Edit Distance](classic-dp.md#edit-distance)
+    - [Maximum Square Submatrix](classic-dp.md#maximum-square-submatrix)
+  - Knapsack Variants
+    - [0/1 Knapsack](classic-dp.md#0-1-knapsack)
+    - [Unbounded Knapsack](classic-dp.md#unbounded-knapsack)
+    - [Partition Equal Subset Sum](classic-dp.md#partition-equal-subset-sum)
+    - [Target Sum](classic-dp.md#target-sum)
+  - String DP
+    - [Longest Common Subsequence (LCS)](classic-dp.md#longest-common-subsequence-lcs-1)
+    - [Edit Distance](classic-dp.md#edit-distance-1)
+    - [Regular Expression Matching](classic-dp.md#regular-expression-matching)
+    - [Wildcard Matching](classic-dp.md#wildcard-matching)
+    - [Palindromic Substrings](classic-dp.md#palindromic-substrings)
+  - Interval DP
+    - [Matrix Chain Multiplication](classic-dp.md#matrix-chain-multiplication)
+    - [Burst Balloons](classic-dp.md#burst-balloons)
+    - [Palindrome Partitioning](classic-dp.md#palindrome-partitioning)
+  - Bitmask / Digit DP
+    - [Traveling Salesman Problem (TSP)](classic-dp.md#traveling-salesman-problem-tsp)
+    - [Assignment Problem](classic-dp.md#assignment-problem)
+    - [Digit Sum Count](classic-dp.md#digit-sum-count)
+  - Tree/DAG DP
+    - [Diameter of Tree](classic-dp.md#diameter-of-tree)
+    - [House Robber III](classic-dp.md#house-robber-iii)
+    - [Longest Path in DAG](classic-dp.md#longest-path-in-dag)
+- [Reinforcement Learning (Model-Free)](reinforcement-learning.md)
+  - [Q-Learning](reinforcement-learning.md#q-learning)
+  - [SARSA](reinforcement-learning.md#sarsa)
+  - [Deep Q-Network (DQN)](reinforcement-learning.md#deep-q-network-dqn)
+  - [Proximal Policy Optimization (PPO)](reinforcement-learning.md#proximal-policy-optimization-ppo)
+  - [A2C / A3C](reinforcement-learning.md#a2c-a3c)
+- [Hierarchical Reinforcement Learning](hrl.md)
+  - [Options Framework](hrl.md#options-framework)
+  - [Feudal Reinforcement Learning](hrl.md#feudal-reinforcement-learning)
+  - [MAXQ Decomposition](hrl.md#maxq-decomposition)
+  - [HIRO](hrl.md#hiro)
+- [Dynamic Movement Primitives](dmps.md)
+  - [DMP Encoding/Decoding](dmps.md#dmp-encoding-decoding)
+  - [Imitation Learning Using DMPs](dmps.md#imitation-learning-using-dmps)
+- [Gaussian Process Modeling](gaussian-process.md)
+  - [Gaussian Process Regression](gaussian-process.md#gaussian-process-regression)
+  - [Sparse Gaussian Processes](gaussian-process.md#sparse-gaussian-processes)
+  - [Bayesian Optimization](gaussian-process.md#bayesian-optimization)
+  - [PILCO](gaussian-process.md#pilco)
+- [Real-Time Control](real-time-control.md)
+  - [PID Controller (P/PI/PD/PID)](real-time-control.md#pid-controller-p-pi-pd-pid)
+  - [Bang-bang Control](real-time-control.md#bang-bang-control)
+  - [Kalman Filter](real-time-control.md#kalman-filter)
+- [Model Predictive Control](mpc.md)
+  - [Finite Horizon MPC](mpc.md#finite-horizon-mpc)
+  - [Nonlinear MPC](mpc.md#nonlinear-mpc)
+  - [Learning-based MPC](mpc.md#learning-based-mpc)
+- [Classical Planning Algorithms](classical-planning.md)
+  - [A*](classical-planning.md#a)
+  - [Dijkstra's](classical-planning.md#dijkstra-s)
+  - [RRT / PRM](classical-planning.md#rrt-prm)
+  - [STRIPS / PDDL](classical-planning.md#strips-pddl)
+
+
 ## Quick Start
 
 Get up and running with Algorithm Kit in minutes:

--- a/docs/mpc.md
+++ b/docs/mpc.md
@@ -1,0 +1,20 @@
+# Model Predictive Control
+
+Use optimization to plan control actions over a horizon.
+
+## Algorithms
+
+### Finite Horizon MPC
+TODO: Implementation forthcoming.
+
+### Nonlinear MPC
+TODO: Implementation forthcoming.
+
+### Learning-based MPC
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Cost functions
+- State and control constraints
+- Receding horizon optimization

--- a/docs/real-time-control.md
+++ b/docs/real-time-control.md
@@ -1,0 +1,20 @@
+# Real-Time Control
+
+Implement fast, reactive control systems with feedback.
+
+## Algorithms
+
+### PID Controller (P/PI/PD/PID)
+TODO: Implementation forthcoming.
+
+### Bang-bang Control
+TODO: Implementation forthcoming.
+
+### Kalman Filter
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Feedback vs feedforward
+- Tuning gains
+- Real-time latency constraints

--- a/docs/reinforcement-learning.md
+++ b/docs/reinforcement-learning.md
@@ -1,0 +1,27 @@
+# Reinforcement Learning (Model-Free)
+
+Teach agents to learn optimal behavior through interaction with an environment.
+
+## Algorithms
+
+### Q-Learning
+TODO: Implementation forthcoming.
+
+### SARSA
+TODO: Implementation forthcoming.
+
+### Deep Q-Network (DQN)
+TODO: Implementation forthcoming.
+
+### Proximal Policy Optimization (PPO)
+TODO: Implementation forthcoming.
+
+### A2C / A3C
+TODO: Implementation forthcoming.
+
+## Concepts
+
+- Exploration vs exploitation
+- Discounted return
+- Temporal difference learning
+- Experience replay and target networks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,15 @@ plugins:
 
 nav:
   - Overview: index.md
+  - Algorithm Families:
+      - Classic Dynamic Programming: classic-dp.md
+      - Reinforcement Learning (Model-Free): reinforcement-learning.md
+      - Hierarchical Reinforcement Learning: hrl.md
+      - Dynamic Movement Primitives: dmps.md
+      - Gaussian Process Modeling: gaussian-process.md
+      - Real-Time Control: real-time-control.md
+      - Model Predictive Control: mpc.md
+      - Classical Planning Algorithms: classical-planning.md
   - API Reference: api.md
   - Contributing: contributing.md
   - Security: SECURITY.md


### PR DESCRIPTION
## Summary
- create skeleton pages for major algorithm families
- link algorithms on main page and navigation
- configure mkdocs navigation for new documentation

## Testing
- `pre-commit run --files mkdocs.yml docs/index.md docs/classic-dp.md docs/classical-planning.md docs/dmps.md docs/gaussian-process.md docs/hrl.md docs/mpc.md docs/real-time-control.md docs/reinforcement-learning.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b61fde61fc8326a1770811132dcdf5