### PR TITLE
chore: add placeholders for dynamic programming

### DIFF
--- a/docs/classic-dp.md
+++ b/docs/classic-dp.md
@@ -5,7 +5,7 @@ Model problems with optimal substructure and overlapping subproblems.
 ## Linear DP
 
 ### Fibonacci
-TODO: Implementation forthcoming.
+TODO: Implementation and example forthcoming.
 
 ### Longest Increasing Subsequence (LIS)
 TODO: Implementation forthcoming.
@@ -102,3 +102,7 @@ TODO: Implementation forthcoming.
 
 ### Longest Path in DAG
 TODO: Implementation forthcoming.
+
+## Flow Diagrams
+
+Flow diagrams illustrating each algorithm will be added in future updates.

--- a/docs/classic-dp.md
+++ b/docs/classic-dp.md
@@ -1,6 +1,6 @@
 # Classic Dynamic Programming
 
-Model problems with optimal substructure and overlapping subproblems.
+Solve discrete optimization and counting problems by exploiting overlapping subproblems and optimal substructure. Dynamic programming shines in path finding, resource allocation, and sequence analysis tasks.
 
 ## Linear DP
 

--- a/docs/classical-planning.md
+++ b/docs/classical-planning.md
@@ -1,6 +1,6 @@
 # Classical Planning Algorithms
 
-Solve planning problems in state or configuration space.
+Solve planning problems by searching through state or configuration space for a sequence of actions that achieves a goal. These methods underpin robotics navigation, scheduling, and AI planning systems.
 
 ## Algorithms
 

--- a/docs/dmps.md
+++ b/docs/dmps.md
@@ -1,6 +1,6 @@
 # Dynamic Movement Primitives
 
-Encode reusable trajectories for motion planning.
+Encode reusable motion trajectories as stable dynamical systems. Dynamic movement primitives let robots reproduce and adapt motions learned from demonstrations.
 
 ## Algorithms
 

--- a/docs/gaussian-process.md
+++ b/docs/gaussian-process.md
@@ -1,6 +1,6 @@
 # Gaussian Process Modeling
 
-Model functions with uncertainty using Bayesian regression.
+Model unknown functions with quantified uncertainty using Bayesian regression. Gaussian processes are well suited for surrogate modeling, regression, and Bayesian optimization.
 
 ## Algorithms
 

--- a/docs/hrl.md
+++ b/docs/hrl.md
@@ -1,6 +1,6 @@
 # Hierarchical Reinforcement Learning
 
-Introduce temporal abstraction and multi-level decision-making.
+Introduce temporal abstraction and multi-level decision making by structuring tasks into subgoals or options. This hierarchy enables efficient exploration and learning for long-horizon problems.
 
 ## Algorithms
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,34 @@ Explore the algorithm landscapes covered by Algorithm Kit.
 
 **Status legend**: :material-code-tags: Code available · :material-progress-clock: Coming Soon
 
+### Family Overviews
+
+Get a feel for the types of problems each family tackles before diving in.
+
+#### Classic Dynamic Programming
+Break complex problems into overlapping subproblems with optimal substructure. Ideal for tasks like path finding, resource allocation, and sequence analysis.
+
+#### Reinforcement Learning (Model-Free)
+Learn policies through trial and error when environment dynamics are unknown. Useful for game playing, robotics, and other sequential decision-making tasks.
+
+#### Hierarchical Reinforcement Learning
+Introduce temporal abstraction via options or subgoals to manage long-horizon tasks more efficiently.
+
+#### Dynamic Movement Primitives
+Encode smooth, reusable motion trajectories as stable dynamical systems, enabling robots to adapt motions to new goals and timings.
+
+#### Gaussian Process Modeling
+Model functions with quantified uncertainty using Bayesian regression—great for surrogate modeling, regression, and Bayesian optimization.
+
+#### Real-Time Control
+Design fast, feedback-driven controllers such as PID or Kalman filters for systems with tight latency requirements.
+
+#### Model Predictive Control
+Solve constrained optimization problems over a moving horizon to compute control actions, balancing performance and safety.
+
+#### Classical Planning Algorithms
+Search state spaces for action sequences that achieve goals in robotics and AI planning domains.
+
 ## Quick Start
 
 Get up and running with Algorithm Kit in minutes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,76 +9,20 @@
 
 ## Algorithm Families
 
-- [Classic Dynamic Programming](classic-dp.md)
-  - Linear DP
-    - [Fibonacci](classic-dp.md#fibonacci)
-    - [Longest Increasing Subsequence (LIS)](classic-dp.md#longest-increasing-subsequence-lis)
-    - [Maximum Subarray (Kadane's Algorithm)](classic-dp.md#maximum-subarray-kadane-s-algorithm)
-    - [House Robber](classic-dp.md#house-robber)
-    - [Climbing Stairs](classic-dp.md#climbing-stairs)
-    - [Jump Game I & II](classic-dp.md#jump-game-i-ii)
-  - 2D / Grid-Based DP
-    - [Unique Paths](classic-dp.md#unique-paths)
-    - [Minimum Path Sum](classic-dp.md#minimum-path-sum)
-    - [Longest Common Subsequence (LCS)](classic-dp.md#longest-common-subsequence-lcs)
-    - [Edit Distance](classic-dp.md#edit-distance)
-    - [Maximum Square Submatrix](classic-dp.md#maximum-square-submatrix)
-  - Knapsack Variants
-    - [0/1 Knapsack](classic-dp.md#0-1-knapsack)
-    - [Unbounded Knapsack](classic-dp.md#unbounded-knapsack)
-    - [Partition Equal Subset Sum](classic-dp.md#partition-equal-subset-sum)
-    - [Target Sum](classic-dp.md#target-sum)
-  - String DP
-    - [Longest Common Subsequence (LCS)](classic-dp.md#longest-common-subsequence-lcs-1)
-    - [Edit Distance](classic-dp.md#edit-distance-1)
-    - [Regular Expression Matching](classic-dp.md#regular-expression-matching)
-    - [Wildcard Matching](classic-dp.md#wildcard-matching)
-    - [Palindromic Substrings](classic-dp.md#palindromic-substrings)
-  - Interval DP
-    - [Matrix Chain Multiplication](classic-dp.md#matrix-chain-multiplication)
-    - [Burst Balloons](classic-dp.md#burst-balloons)
-    - [Palindrome Partitioning](classic-dp.md#palindrome-partitioning)
-  - Bitmask / Digit DP
-    - [Traveling Salesman Problem (TSP)](classic-dp.md#traveling-salesman-problem-tsp)
-    - [Assignment Problem](classic-dp.md#assignment-problem)
-    - [Digit Sum Count](classic-dp.md#digit-sum-count)
-  - Tree/DAG DP
-    - [Diameter of Tree](classic-dp.md#diameter-of-tree)
-    - [House Robber III](classic-dp.md#house-robber-iii)
-    - [Longest Path in DAG](classic-dp.md#longest-path-in-dag)
-- [Reinforcement Learning (Model-Free)](reinforcement-learning.md)
-  - [Q-Learning](reinforcement-learning.md#q-learning)
-  - [SARSA](reinforcement-learning.md#sarsa)
-  - [Deep Q-Network (DQN)](reinforcement-learning.md#deep-q-network-dqn)
-  - [Proximal Policy Optimization (PPO)](reinforcement-learning.md#proximal-policy-optimization-ppo)
-  - [A2C / A3C](reinforcement-learning.md#a2c-a3c)
-- [Hierarchical Reinforcement Learning](hrl.md)
-  - [Options Framework](hrl.md#options-framework)
-  - [Feudal Reinforcement Learning](hrl.md#feudal-reinforcement-learning)
-  - [MAXQ Decomposition](hrl.md#maxq-decomposition)
-  - [HIRO](hrl.md#hiro)
-- [Dynamic Movement Primitives](dmps.md)
-  - [DMP Encoding/Decoding](dmps.md#dmp-encoding-decoding)
-  - [Imitation Learning Using DMPs](dmps.md#imitation-learning-using-dmps)
-- [Gaussian Process Modeling](gaussian-process.md)
-  - [Gaussian Process Regression](gaussian-process.md#gaussian-process-regression)
-  - [Sparse Gaussian Processes](gaussian-process.md#sparse-gaussian-processes)
-  - [Bayesian Optimization](gaussian-process.md#bayesian-optimization)
-  - [PILCO](gaussian-process.md#pilco)
-- [Real-Time Control](real-time-control.md)
-  - [PID Controller (P/PI/PD/PID)](real-time-control.md#pid-controller-p-pi-pd-pid)
-  - [Bang-bang Control](real-time-control.md#bang-bang-control)
-  - [Kalman Filter](real-time-control.md#kalman-filter)
-- [Model Predictive Control](mpc.md)
-  - [Finite Horizon MPC](mpc.md#finite-horizon-mpc)
-  - [Nonlinear MPC](mpc.md#nonlinear-mpc)
-  - [Learning-based MPC](mpc.md#learning-based-mpc)
-- [Classical Planning Algorithms](classical-planning.md)
-  - [A*](classical-planning.md#a)
-  - [Dijkstra's](classical-planning.md#dijkstra-s)
-  - [RRT / PRM](classical-planning.md#rrt-prm)
-  - [STRIPS / PDDL](classical-planning.md#strips-pddl)
+Explore the algorithm landscapes covered by Algorithm Kit.
 
+| Family | Highlighted Algorithms | Status |
+| --- | --- | --- |
+| [Classic Dynamic Programming](classic-dp.md) | Fibonacci, LIS, Knapsack | :material-progress-clock: Coming Soon |
+| [Reinforcement Learning (Model-Free)](reinforcement-learning.md) | Q-Learning, SARSA, DQN | :material-progress-clock: Coming Soon |
+| [Hierarchical Reinforcement Learning](hrl.md) | Options, Feudal RL, MAXQ, HIRO | :material-progress-clock: Coming Soon |
+| [Dynamic Movement Primitives](dmps.md) | DMP Encoding, Imitation Learning | :material-progress-clock: Coming Soon |
+| [Gaussian Process Modeling](gaussian-process.md) | Regression, Bayesian Optimization | :material-progress-clock: Coming Soon |
+| [Real-Time Control](real-time-control.md) | PID, Bang-bang, Kalman Filter | :material-progress-clock: Coming Soon |
+| [Model Predictive Control](mpc.md) | Finite Horizon, Nonlinear, Learning-based | :material-progress-clock: Coming Soon |
+| [Classical Planning Algorithms](classical-planning.md) | A*, Dijkstra, RRT, STRIPS | :material-progress-clock: Coming Soon |
+
+**Status legend**: :material-code-tags: Code available · :material-progress-clock: Coming Soon
 
 ## Quick Start
 

--- a/docs/mpc.md
+++ b/docs/mpc.md
@@ -1,6 +1,6 @@
 # Model Predictive Control
 
-Use optimization to plan control actions over a horizon.
+Use constrained optimization to plan control actions over a moving horizon. Model predictive control balances performance with constraint satisfaction in process control and robotics.
 
 ## Algorithms
 

--- a/docs/real-time-control.md
+++ b/docs/real-time-control.md
@@ -1,6 +1,6 @@
 # Real-Time Control
 
-Implement fast, reactive control systems with feedback.
+Implement fast, reactive control systems that rely on continuous feedback. These methods keep robots and embedded systems stable under tight latency constraints.
 
 ## Algorithms
 

--- a/docs/reinforcement-learning.md
+++ b/docs/reinforcement-learning.md
@@ -1,6 +1,6 @@
 # Reinforcement Learning (Model-Free)
 
-Teach agents to learn optimal behavior through interaction with an environment.
+Teach agents to learn optimal behavior through trial-and-error interaction when the environment dynamics are unknown. Model-free approaches focus on value functions and policies derived directly from experience.
 
 ## Algorithms
 

--- a/src/algokit/__init__.py
+++ b/src/algokit/__init__.py
@@ -5,6 +5,9 @@ __author__ = "Jeff Richley"
 __email__ = "jeffrichley@gmail.com"
 
 
+from algokit.classic_dp import fibonacci
+
+
 def main_function(input_data: str | None) -> str:
     """Main function for Algorithm Kit.
 
@@ -22,4 +25,4 @@ def main_function(input_data: str | None) -> str:
     return f"Processed: {input_data}"
 
 
-__all__ = ["main_function"]
+__all__ = ["main_function", "fibonacci"]

--- a/src/algokit/classic_dp.py
+++ b/src/algokit/classic_dp.py
@@ -1,0 +1,14 @@
+"""Classic dynamic programming algorithms."""
+
+from __future__ import annotations
+
+
+def fibonacci(n: int) -> int:
+    """Placeholder for Fibonacci dynamic programming algorithm.
+
+    TODO: Implement the algorithm.
+    """
+    raise NotImplementedError("Fibonacci algorithm not yet implemented")
+
+
+__all__ = ["fibonacci"]


### PR DESCRIPTION
## Summary
- replace Fibonacci example with TODO placeholders in classic dynamic programming docs
- add flow-diagram placeholder section
- adjust main index table to mark dynamic programming as coming soon

## Testing
- `nox -s lint` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `ruff check src tests`
- `black --check src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b62907d7888326b1582baa75abf9ba