### PR TITLE
fix(tests): correct sliding-mode adaptive-gain test parameters

### DIFF
--- a/tests/control/test_sliding_mode.py
+++ b/tests/control/test_sliding_mode.py
@@ -723,14 +723,17 @@ class TestSlidingModeAdvancedFeatures:
     @pytest.mark.unit
     def test_adaptive_gain_increases_with_disturbance(self) -> None:
         """Test adaptive gain update based on sliding surface magnitude."""
-        # Arrange - Set up test fixtures and inputs
+        # Arrange - Lyapunov law dK/dt = eta*|s| - rho*K has steady-state
+        # K* = eta*|s|/rho. Need eta*|s| > rho*K_init so dK(0) > 0 and the
+        # gain actually grows: with |s|=10, rho=0.5 (default), K_init=5,
+        # eta must exceed 0.25.
         config = SlidingModeConfig(
             state_dim=2,
             control_dim=1,
             C=[1.0, 0.0],
             K_init=5.0,
             adaptive_gain=True,
-            eta=0.1,
+            eta=0.5,
         )
         controller = SlidingModeController(config)
 


### PR DESCRIPTION
## Summary

`test_adaptive_gain_increases_with_disturbance` asserts the controller's switching gain grows under sustained disturbance, but with the original parameters the gain correctly **decreases** per the documented Lyapunov law — the test was wrong, not the controller.

## Diagnosis

Update law: `dK/dt = eta*|s| - rho*K` (sliding_mode.py:649).

Original test parameters:
- `eta = 0.1`, `rho = 0.5` (default), `K_init = 5.0`, sliding surface `|s| = 10`
- At t=0: `dK = 0.1*10 - 0.5*5 = -1.5` (NEGATIVE)
- Steady-state: `K* = eta*|s|/rho = 2.0` (BELOW K_init)
- Deterministic failure: `final_gain = 4.853 < 5.0 = initial_gain`

The controller is doing exactly what its spec says. Gain decays from K_init=5 toward K*=2.

## Fix

Bump `eta` from 0.1 to 0.5 so `dK(0) > 0` and steady-state K* = 10 > K_init. Added a comment explaining the constraint.

## Test plan

- [x] Target test passes deterministically (3/3 confirmed)
- [x] Full suite: 1074 passed, 0 failed
- [x] Closes #36